### PR TITLE
Added css class to post container when media is present

### DIFF
--- a/includes/class-public.php
+++ b/includes/class-public.php
@@ -129,6 +129,9 @@ class RFBP_Public {
 		);
 
 		$atts = shortcode_atts( $defaults, $atts );
+		
+		$post_classes = array();
+		$post_classes[] = 'rfbp-post';		
 
 		ob_start();
 ?>
@@ -147,6 +150,10 @@ class RFBP_Public {
 
 				$shortened = false;
 				$content = $p['content'];
+				
+				if ( $opts['img_size'] !== 'dont_show' && isset( $p['image'] ) && ! empty( $p['image'] ) ) {
+				    $post_classes[] = 'rfbp-post-with-media';
+				}				
 
 				// shorten content if it exceed the set excerpt length
 				if ( strlen( $content ) > $atts['excerpt_length'] ) {
@@ -158,7 +165,7 @@ class RFBP_Public {
 				}
 ?>
 
-					<<?php echo $atts['el']; ?> class="rfbp-post">
+					<<?php echo $atts['el']; ?> class="<?php echo implode(" ", $post_classes); ?>">
 					<h4 class="rfbp-heading"><a class="rfbp-link" href="<?php echo $p['post_link']; ?>" rel="external nofollow" target="<?php echo $link_target; ?>">
 						<?php echo $p['name']; ?>
 					</a></h4>

--- a/includes/class-public.php
+++ b/includes/class-public.php
@@ -128,10 +128,7 @@ class RFBP_Public {
 			'show_link_previews' => $opts['load_css']
 		);
 
-		$atts = shortcode_atts( $defaults, $atts );
-		
-		$post_classes = array();
-		$post_classes[] = 'rfbp-post';		
+		$atts = shortcode_atts( $defaults, $atts );	
 
 		ob_start();
 ?>
@@ -147,6 +144,8 @@ class RFBP_Public {
 			$link_target = ( $opts['link_new_window'] ) ? "_blank" : '';
 
 			foreach ( $posts as $p ) {
+				$post_classes = array();
+				$post_classes[] = 'rfbp-post';	
 
 				$shortened = false;
 				$content = $p['content'];


### PR DESCRIPTION
Added css class to post container when media is set to show in the settings and is present in the post. This way additional CSS styling can be applied when media is present.

Example of advanced styling:

![image](https://cloud.githubusercontent.com/assets/6427451/17616261/e16a4594-6073-11e6-96a9-cb97c8e5803b.png)

As you can see the heading/text/meta info are pushed to the right when media is present.
